### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/js/dropdowns-enhancement.js
+++ b/js/dropdowns-enhancement.js
@@ -44,7 +44,7 @@
 
             if (touchSupport && !$parent.closest('.navbar-nav').length && !menuTree[0].find(backdrop).length) {
                 // if mobile we use a backdrop because click events don't delegate
-                $('<div class="' + backdrop.substr(1) + '"/>').appendTo(menuTree[0]).on('click', closeOpened)
+                $('<div class="' + backdrop.slice(1) + '"/>').appendTo(menuTree[0]).on('click', closeOpened)
             }
 
             for (var i = 0, s = menuTree.length; i < s; i++) {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.